### PR TITLE
bug: incomplete submodule setting name to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Fixed
 
+- Fixed submodule crashing bug and document/Symbol request failure
+  ([#233](https://github.com/fortran-lang/fortls/issues/233))
 - Fixed debug interface parser not loading all configuration files
   ([#221](https://github.com/fortran-lang/fortls/issues/221))
 - Fixed name mangling of type-bound procedure pointers while hovering

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -301,7 +301,12 @@ class LangServer:
         # Add scopes to outline view
         test_output = []
         for scope in file_obj.ast.get_scopes():
-            if (scope.name[0] == "#") or (scope.get_type() == SELECT_TYPE_ID):
+
+            if (
+                not scope.name
+                or scope.name[0] == "#"
+                or scope.get_type() == SELECT_TYPE_ID
+            ):
                 continue
             scope_tree = scope.FQSN.split("::")
             if len(scope_tree) > 2:

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -303,9 +303,9 @@ class LangServer:
         for scope in file_obj.ast.get_scopes():
 
             if (
-                not scope.name
-                or scope.name[0] == "#"
-                or scope.get_type() == SELECT_TYPE_ID
+                not scope.name  # Skip empty strings
+                or scope.name.startswith("#")  # Skip comments
+                or scope.get_type() == SELECT_TYPE_ID  # Skip select types
             ):
                 continue
             scope_tree = scope.FQSN.split("::")

--- a/fortls/objects.py
+++ b/fortls/objects.py
@@ -745,7 +745,7 @@ class Submodule(Module):
         file_ast: FortranAST,
         line_number: int,
         name: str,
-        ancestor_name: str = None,
+        ancestor_name: str = "",
     ):
         super().__init__(file_ast, line_number, name)
         self.ancestor_name = ancestor_name
@@ -766,7 +766,7 @@ class Submodule(Module):
         return []
 
     def resolve_inherit(self, obj_tree, inherit_version):
-        if self.ancestor_name is None:
+        if not self.ancestor_name:
             return
         if self.ancestor_name in obj_tree:
             self.ancestor_obj = obj_tree[self.ancestor_name][0]

--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -586,8 +586,8 @@ def read_submod_def(line: str):
     if submod_match is None:
         return None
 
-    parent_name: str = None
-    name: str = None
+    parent_name: str = ""
+    name: str = ""
     trailing_line = line[submod_match.end(0) :].split("!")[0]
     trailing_line = trailing_line.strip()
     parent_match = FRegex.WORD.match(trailing_line)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -14,3 +14,20 @@ def test_line_continuations():
     except Exception as e:
         print(e)
         assert False
+
+
+def test_submodule():
+    file_path = test_dir / "parse" / "submodule.f90"
+    file = FortranFile(str(file_path))
+    err_str, _ = file.load_from_disk()
+    assert err_str is None
+    try:
+        ast = file.parse()
+        assert True
+        assert ast.scope_list[0].name == "val"
+        assert ast.scope_list[0].ancestor_name == "p1"
+        assert ast.scope_list[1].name == ""
+        assert ast.scope_list[1].ancestor_name == "p2"
+    except Exception as e:
+        print(e)
+        assert False

--- a/test/test_source/parse/submodule.f90
+++ b/test/test_source/parse/submodule.f90
@@ -1,0 +1,4 @@
+submodule (p1) val
+end
+
+submodule (p2)


### PR DESCRIPTION
The submodule AST node was setting the name of the
object to None instead of an empty string which caused
havoc in all sorts of places.

Fixes #233