### PR TITLE
fix: len and kind attribute mistaken as variables

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,9 @@ omit =
     fortls/__init__.py
     fortls/version.py
     fortls/schema.py
+concurrency = multiprocessing
+parallel = true
+sigterm = true
 
 [report]
 exclude_lines =

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 ### Fixed
 
+- Fixed bug where diagnostic messages were raised for non-existent variables
+  ([#173](https://github.com/fortran-lang/fortls/issues/173))
+  ([#175](https://github.com/fortran-lang/fortls/issues/175))
 - Fixed submodule crashing bug and document/Symbol request failure
   ([#233](https://github.com/fortran-lang/fortls/issues/233))
 - Fixed debug interface parser not loading all configuration files

--- a/fortls/ftypes.py
+++ b/fortls/ftypes.py
@@ -15,7 +15,8 @@ class VarInfo:
     #: keywords associated with this variable e.g. SAVE, DIMENSION, etc.
     keywords: list[str]  #: Keywords associated with variable
     var_names: list[str]  #: Variable names
-    var_kind: str = field(default=None)  #: Kind of variable e.g. ``INTEGER*4`` etc.
+    #: Kind of variable e.g. ``INTEGER*4`` etc.
+    var_kind: str | None = field(default=None)
 
 
 @dataclass
@@ -106,10 +107,11 @@ class SubInfo:
 class ResultSig:
     """Holds information about the RESULT section of a Fortran FUNCTION"""
 
-    name: str = field(default=None)  #: Variable name of result
-    type: str = field(default=None)  #: Variable type of result
+    name: str | None = field(default=None)  #: Variable name of result
+    type: str | None = field(default=None)  #: Variable type of result
     #: Keywords associated with the result variable, can append without init
     keywords: list[str] = field(default_factory=list)
+    kind: str | None = field(default=None)  #: Variable kind of result
 
 
 @dataclass

--- a/fortls/ftypes.py
+++ b/fortls/ftypes.py
@@ -109,9 +109,9 @@ class ResultSig:
 
     name: str | None = field(default=None)  #: Variable name of result
     type: str | None = field(default=None)  #: Variable type of result
+    kind: str | None = field(default=None)  #: Variable kind of result
     #: Keywords associated with the result variable, can append without init
     keywords: list[str] = field(default_factory=list)
-    kind: str | None = field(default=None)  #: Variable kind of result
 
 
 @dataclass

--- a/fortls/objects.py
+++ b/fortls/objects.py
@@ -1749,11 +1749,17 @@ class Variable(FortranObj):
             desc_obj_name = type_match.group(2).strip().lower()
             if desc_obj_name not in known_types:
                 type_def = find_in_scope(
-                    self.parent, desc_obj_name, obj_tree, interface=interface
+                    self.parent,
+                    desc_obj_name,
+                    obj_tree,
+                    interface=interface,
                 )
                 if type_def is None:
                     type_defs = find_in_workspace(
-                        obj_tree, desc_obj_name, filter_public=True, exact_match=True
+                        obj_tree,
+                        desc_obj_name,
+                        filter_public=True,
+                        exact_match=True,
                     )
                     known_types[desc_obj_name] = None
                     var_type = type_match.group(1).strip().lower()
@@ -1804,8 +1810,8 @@ class Method(Variable):  # i.e. TypeBound procedure
         var_desc: str,
         keywords: list,
         keyword_info: dict,
+        proc_ptr: str = "",  # procedure pointer e.g. `foo` in `procedure(foo)`
         link_obj=None,
-        proc_ptr: str = "",  # procedure pointer
     ):
         super().__init__(
             file_ast,

--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -167,7 +167,7 @@ def parse_var_keywords(test_str: str) -> tuple[list[str], str]:
     return keywords, test_str
 
 
-def read_var_def(line: str, var_type: str = None, fun_only: bool = False):
+def read_var_def(line: str, var_type: str | None = None, fun_only: bool = False):
     """Attempt to read variable definition line"""
 
     def parse_kind(line: str):
@@ -1499,9 +1499,9 @@ class FortranFile:
                         line_no,
                         name=obj_info.result.name,
                         var_desc=obj_info.result.type,
-                        kind=obj_info.result.kind,
                         keywords=keywords,
                         keyword_info=keyword_info,
+                        kind=obj_info.result.kind,
                     )
                     file_ast.add_variable(new_obj)
                 log.debug("%s !!! FUNCTION - Ln:%d", line, line_no)

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -135,7 +135,7 @@ class FortranRegularExpressions:
     )
     # Object regex patterns
     CLASS_VAR: Pattern = compile(r"(TYPE|CLASS)[ ]*\(", I)
-    DEF_KIND: Pattern = compile(r"([a-z]*)[ ]*\((?:KIND|LEN)?[ =]*([a-z_]\w*)", I)
+    DEF_KIND: Pattern = compile(r"(\w*)[ ]*\((?:KIND|LEN)?[ =]*(\w*)", I)
     OBJBREAK: Pattern = compile(r"[\/\-(.,+*<>=$: ]", I)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,6 @@ write_to = "fortls/_version.py"
 profile = "black"
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.2.0"
 addopts = "-v --cov=fortls --cov-report=html --cov-report=xml --cov-context=test"
 testpaths = ["fortls", "test"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,9 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    pytest >= 5.4.3
-    pytest-cov >= 2.12.1
+    pytest >= 7.2.0
+    pytest-cov >= 4.0.0
+    pytest-xdist >= 3.0.2
     black
     isort
     pre-commit

--- a/test/test_server_completion.py
+++ b/test/test_server_completion.py
@@ -34,7 +34,7 @@ def test_comp1():
     string += comp_request(file_path, 21, 20)
     string += comp_request(file_path, 21, 42)
     string += comp_request(file_path, 23, 26)
-    errcode, results = run_request(string, ["--use_signature_help"])
+    errcode, results = run_request(string, ["--use_signature_help", "-n1"])
     assert errcode == 0
 
     exp_results = (

--- a/test/test_server_diagnostics.py
+++ b/test/test_server_diagnostics.py
@@ -416,3 +416,15 @@ def test_keyword_arg_list_var_names():
     errcode, results = run_request(string, ["-n", "1"])
     assert errcode == 0
     assert results[1]["diagnostics"] == []
+
+
+def test_attribute_and_variable_name_collision():
+    """Test variables named with attribute names do not cause a collision."""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir / "diag")})
+    file_path = str(test_dir / "diag" / "var_shadowing_keyword_arg.f90")
+    string += write_rpc_notification(
+        "textDocument/didOpen", {"textDocument": {"uri": file_path}}
+    )
+    errcode, results = run_request(string, ["-n", "1"])
+    assert errcode == 0
+    assert results[1]["diagnostics"] == []

--- a/test/test_source/diag/test_var_shadowing_keyword_arg.f90
+++ b/test/test_source/diag/test_var_shadowing_keyword_arg.f90
@@ -1,0 +1,11 @@
+module var_shadowing_keyword_arg
+  character(len=6), parameter :: TEST = "4.10.4"
+  character(len=6, kind=4), parameter :: TEST2 = "4.10.4"
+  real(kind=8) :: a
+end module var_shadowing_keyword_arg
+
+program program_var_shadowing_keyword_arg
+  use var_shadowing_keyword_arg
+  integer :: len
+  integer :: kind
+end program program_var_shadowing_keyword_arg


### PR DESCRIPTION
Preliminary work on parsing attributes such as kind, len
as separate variables in the AST node.
They can then be excluded from the dublication check
for diagnostics.

Fixes #173
Fixes #175