### PR TITLE
Extending file preprocessing

### DIFF
--- a/test/test_preproc.py
+++ b/test/test_preproc.py
@@ -24,12 +24,25 @@ def test_hover():
     file_path = root_dir / "preproc.F90"
     string += hover_req(file_path, 5, 8)  # user defined type
     string += hover_req(file_path, 7, 30)  # variable
-    string += hover_req(file_path, 7, 40)  # multi-lin variable
+    string += hover_req(file_path, 7, 40)  # multi-line variable
     string += hover_req(file_path, 8, 7)  # function with if conditional
     string += hover_req(file_path, 9, 7)  # multiline function with if conditional
     string += hover_req(file_path, 10, 15)  # defined without ()
     file_path = root_dir / "preproc_keywords.F90"
     string += hover_req(file_path, 6, 2)  # ignores PP across Fortran line continuations
+    file_path = root_dir / "preproc_ifdef.F90"
+    string += hover_req(file_path, 21, 15)  # defined inside `if` block
+    string += hover_req(file_path, 22, 15)  # defined inside `elif` block
+    string += hover_req(file_path, 23, 15)  # defined inside `ifndef` block
+    file_path = root_dir / "preproc_use.F90"
+    string += hover_req(file_path, 7, 15)  # Correct subroutine definition from mpi_f08
+    string += hover_req(file_path, 7, 30)  # Correct type of MPI_COMM_WORLD
+    file_path = root_dir / "preproc_use_include.F90"
+    string += hover_req(file_path, 3, 15)  # Correct subroutine definition from mpi_f08
+    string += hover_req(file_path, 3, 30)  # Correct type of MPI_COMM_WORLD
+    string += hover_req(
+        file_path, 4, 15
+    )  # Found definition of `omp_get_num_threads` function from omp_lib module
     config = str(root_dir / ".pp_conf.json")
     errcode, results = run_request(string, ["--config", config])
     assert errcode == 0
@@ -49,6 +62,44 @@ def test_hover():
         ),
         "```fortran90\n#define SUCCESS .true.\n```",
         "```fortran90\nREAL, CONTIGUOUS, POINTER, DIMENSION(:) :: var1\n```",
+        "```fortran90\n#define CUSTOM_MACRO 0\n```",
+        "```fortran90\n#define SECOND_CUSTOM_MACRO 1\n```",
+        "```fortran90\n#define THIRD_CUSTOM_MACRO 0\n```",
+        (
+            "```fortran90"
+            "\nSUBROUTINE MPI_Comm_size(comm, size, ierror=ierror)"
+            "\n TYPE(MPI_Comm), INTENT(IN) :: comm"
+            "\n INTEGER(C_INT), INTENT(OUT) :: size"
+            "\n INTEGER(C_INT), OPTIONAL, INTENT(OUT) :: ierror"
+            "\n"
+            "```"
+            "\n-----\n"
+            "\n**Parameters:**     "
+            "\n`comm` Communicator.   "
+            "\n`size` Size of communicator.   "
+            "\n`ierror` Error status."
+        ),
+        "```fortran90\nTYPE(MPI_Comm) :: MPI_COMM_WORLD\n```",
+        (
+            "```fortran90"
+            "\nSUBROUTINE MPI_Comm_size(comm, size, ierror=ierror)"
+            "\n TYPE(MPI_Comm), INTENT(IN) :: comm"
+            "\n INTEGER(C_INT), INTENT(OUT) :: size"
+            "\n INTEGER(C_INT), OPTIONAL, INTENT(OUT) :: ierror"
+            "\n"
+            "```"
+            "\n-----\n"
+            "\n**Parameters:**     "
+            "\n`comm` Communicator.   "
+            "\n`size` Size of communicator.   "
+            "\n`ierror` Error status."
+        ),
+        "```fortran90\nTYPE(MPI_Comm) :: MPI_COMM_WORLD\n```",
+        (
+            "```fortran90"
+            "\nINTEGER FUNCTION omp_get_num_threads() RESULT(omp_get_num_threads)"
+            "\n```"
+        ),
     )
     assert len(ref_results) == len(results) - 1
     check_return(results[1:], ref_results)

--- a/test/test_source/pp/.pp_conf.json
+++ b/test/test_source/pp/.pp_conf.json
@@ -7,5 +7,5 @@
   "pp_suffixes": [".h", ".F90"],
   "incl_suffixes": [".h"],
   "include_dirs": ["include"],
-  "pp_defs": { "HAVE_CONTIGUOUS": "" }
+  "pp_defs": { "HAVE_CONTIGUOUS": "", "DUMMY": "" },
 }

--- a/test/test_source/pp/include/mpi.h
+++ b/test/test_source/pp/include/mpi.h
@@ -3,4 +3,4 @@
 #else
     use mpi_f08
 #endif
-#include "omp.h"§§§§
+#include "omp.h"

--- a/test/test_source/pp/include/mpi.h
+++ b/test/test_source/pp/include/mpi.h
@@ -1,0 +1,6 @@
+#ifdef USE_MPI
+    use mpi
+#else
+    use mpi_f08
+#endif
+#include "omp.h"§§§§

--- a/test/test_source/pp/include/omp.h
+++ b/test/test_source/pp/include/omp.h
@@ -1,0 +1,1 @@
+use omp_lib

--- a/test/test_source/pp/preproc_ifdef.F90
+++ b/test/test_source/pp/preproc_ifdef.F90
@@ -1,0 +1,25 @@
+program preprocessor
+#if defined(DUMMY)
+#define CUSTOM_MACRO 0
+#else
+#define CUSTOM_MACRO 1
+#endif
+#ifdef DUMMY_MACRO
+#define SECOND_CUSTOM_MACRO 0
+#elif defined DUMMY
+#define SECOND_CUSTOM_MACRO 1
+#else
+#define SECOND_CUSTOM_MACRO 2
+#endif
+
+#ifndef DUMMY_MACRO
+#define THIRD_CUSTOM_MACRO 0
+#elif defined (SECOND_DUMMY_MACRO)
+#define THIRD_CUSTOM_MACRO 1
+#else
+#define THIRD_CUSTOM_MACRO 2
+#endif
+    print*, CUSTOM_MACRO
+    print*, SECOND_CUSTOM_MACRO
+    print*, THIRD_CUSTOM_MACRO
+end program preprocessor

--- a/test/test_source/pp/preproc_use.F90
+++ b/test/test_source/pp/preproc_use.F90
@@ -1,0 +1,9 @@
+program preprocessor
+#ifdef USE_MPI
+    use mpi
+#else
+    use mpi_f08
+#endif
+    integer :: comm_size, ierr
+    call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+end program preprocessor

--- a/test/test_source/pp/preproc_use_include.F90
+++ b/test/test_source/pp/preproc_use_include.F90
@@ -1,0 +1,6 @@
+program preprocessor
+#include "mpi.h"
+    integer :: comm_size, ierr
+    call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+    print*, omp_get_num_threads()
+end program preprocessor

--- a/test/test_source/pp/sources/mpi.f90
+++ b/test/test_source/pp/sources/mpi.f90
@@ -1,0 +1,10 @@
+module mpi
+
+    integer, parameter :: MPI_COMM_WORLD = 0
+
+contains
+
+    subroutine MPI_Comm_size(comm, size, ierr)
+        integer :: comm, size, ierr
+    end subroutine MPI_Comm_size
+end module mpi

--- a/test/test_source/pp/sources/mpi_f08.f90
+++ b/test/test_source/pp/sources/mpi_f08.f90
@@ -1,0 +1,17 @@
+module mpi_f08
+use iso_c_binding
+
+    type :: MPI_Comm
+        integer :: MPI_VAL
+    end type MPI_Comm
+
+    type(MPI_Comm) :: MPI_COMM_WORLD
+
+contains
+
+    subroutine MPI_Comm_size(comm, size, ierror)
+        type(MPI_Comm),           intent(in)  :: comm       !< Communicator.
+        integer(C_INT),           intent(out) :: size       !< Size of communicator.
+        integer(C_INT), optional, intent(out) :: ierror     !< Error status.
+    end subroutine MPI_Comm_size
+end module mpi_f08


### PR DESCRIPTION
Hello everyone!

This request is targeting couple issues with file preprocessing:

1. Preprocessing directive `#else` is not taken into consideration in case all above directives are not resolving. This issue is resolved in parse_fortran.py:2166
2. `#include` statement can add something new to the AST, e.g. module usage, functions, variables, etc. In such case I would like to see definitions in a hover. To resolve this issue, I added `pp_adds` return value to `preprocess_file` and `FortranFile.preprocess` methods. In order to resolve all additional definitions, I added a loop over new lines in `FortranFile.parse` method.

Some tests were also added.
@gnikit, let me know what you think
Thanks