### PR TITLE
fix: evaluates langid only at LSP creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 ### Fixed
 
+- Fixed bug where the `langid` was not propagated correctly from the user
+  settings to the LSP creation stage for all types of requests.
+  ([#257](https://github.com/fortran-lang/fortls/issues/257))
 - Fixed end of scope for `CRITICAL` keyword blocks
   ([#255](https://github.com/fortran-lang/fortls/issues/255))
 - Fixed bug where completion of interfaces in USE ONLY would produce the snippet

--- a/fortls/helper_functions.py
+++ b/fortls/helper_functions.py
@@ -582,7 +582,7 @@ def get_var_stack(line: str) -> list[str]:
         return None
 
 
-def fortran_md(code: str, docs: str | None, langid: str = "fortran90"):
+def fortran_md(code: str, docs: str | None):
     """Convert Fortran code to markdown
 
     Parameters
@@ -591,9 +591,6 @@ def fortran_md(code: str, docs: str | None, langid: str = "fortran90"):
         Fortran code
     docs : str | None
         Documentation string
-    langid : str, optional
-        Language ID, by default 'fortran90'
-
     Returns
     -------
     str
@@ -601,7 +598,8 @@ def fortran_md(code: str, docs: str | None, langid: str = "fortran90"):
     """
     msg = ""
     if code:
-        msg = f"```{langid}\n{code}\n```"
+        msg = "```{langid}\n"   # This gets inserted later
+        msg += f"{code}\n```"
     # Add documentation
     if docs:  # if docs is not None or ""
         msg += f"\n-----\n{docs}"


### PR DESCRIPTION
We do a lazy evaluation of the `langid`, only
replacing it with a value at the LSP creation stage.
This allows us to better isolate the LSP
and the AST parts of the server.

Fixes #257