### PR TITLE
Fix #291 hover multi-line parameter signature

### DIFF
--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -1451,7 +1451,7 @@ class FortranFile:
                             _, col = find_word_in_line(line, name)
                             match = FRegex.PARAMETER_VAL.match(line[col:])
                             if match:
-                                var = match.group(1).strip()
+                                var = " ".join(match.group(1).strip().split())
                                 new_var.set_parameter_val(var)
 
                         # Check if the "variable" is external and if so cycle

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -93,7 +93,7 @@ class FortranRegularExpressions:
         r"CONTIGUOUS)",
         I,
     )
-    PARAMETER_VAL: Pattern = compile(r"\w*[\s\&]*=[\s\&]*([\w\.\*\-\+\\\'\"]*)", I)
+    PARAMETER_VAL: Pattern = compile(r"\w*[\s\&]*=(([\s\&]*[\w\.\-\+\*\/\'\"])*)", I)
     TATTR_LIST: Pattern = compile(
         r"[ ]*,[ ]*(PUBLIC|PRIVATE|ABSTRACT|EXTENDS\(\w*\))", I
     )

--- a/test/test_server_hover.py
+++ b/test/test_server_hover.py
@@ -70,6 +70,73 @@ def test_hover_parameter():
     validate_hover(results, ref_results)
 
 
+def test_hover_parameter_eqnospace():
+    """Test that hover parameters display value correctly"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 11, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_no_space = 123\n```"]
+    validate_hover(results, ref_results)
+
+
+def test_hover_parameter_morespace():
+    """Test that hover parameters display value correctly"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 12, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_more_space = 123\n```"]
+    validate_hover(results, ref_results)
+
+
+def test_hover_parameter_var_sum():
+    """Test that hover parameters display value correctly with sum"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 13, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_sum1 = 1 + 23\n```"]
+    validate_hover(results, ref_results)
+
+
+def test_hover_parameter_var_neg():
+    """Test that hover parameters display value correctly with extraction"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 14, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_ex1 = 1 - 23\n```"]
+    validate_hover(results, ref_results)
+
+
+def test_hover_parameter_var_mul():
+    """Test that hover parameters display value correctly with
+    multiplication and spaces"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 15, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_mul1 = 1  *   23\n```"]
+    validate_hover(results, ref_results)
+
+
+def test_hover_parameter_var_div():
+    """Test that hover parameters display value correctly with value of division"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 16, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_div1 = 1/1\n```"]
+    validate_hover(results, ref_results)
+
+
 def test_hover_parameter_nested():
     """Test that hover parameters using other parameter values works"""
     string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})

--- a/test/test_server_hover.py
+++ b/test/test_server_hover.py
@@ -122,7 +122,7 @@ def test_hover_parameter_var_mul():
     string += hover_req(file_path, 15, 28)
     errcode, results = run_request(string, fortls_args=["--sort_keywords"])
     assert errcode == 0
-    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_mul1 = 1  *   23\n```"]
+    ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_mul1 = 1 * 23\n```"]
     validate_hover(results, ref_results)
 
 
@@ -134,6 +134,20 @@ def test_hover_parameter_var_div():
     errcode, results = run_request(string, fortls_args=["--sort_keywords"])
     assert errcode == 0
     ref_results = ["```fortran90\nINTEGER, PARAMETER :: var_div1 = 1/1\n```"]
+    validate_hover(results, ref_results)
+
+
+def test_hover_parameter_var_multiline2():
+    """Test that hover parameters display value correctly with
+    multiplication and spaces. Item 2"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 17, 28)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = [
+        "```fortran90\nINTEGER, PARAMETER :: var_multi2 = 1 * 23 + 2 /1\n```"
+    ]
     validate_hover(results, ref_results)
 
 

--- a/test/test_source/hover/parameters.f90
+++ b/test/test_source/hover/parameters.f90
@@ -15,4 +15,7 @@ program params
     integer, parameter :: var_ex1  = 1 - 23
     integer, parameter :: var_mul1  = 1  *   23
     integer, parameter :: var_div1  = 1/1
+    INTEGER, PARAMETER :: var_multi2 = 1 *   &
+                                        23 + &
+                                        2 /1        ! comment
 end program params

--- a/test/test_source/hover/parameters.f90
+++ b/test/test_source/hover/parameters.f90
@@ -9,4 +9,10 @@ program params
     logical(kind=8), parameter :: long_bool = .true.
     character(len=5), parameter :: sq_str = '12345'
     character(len=5), parameter :: dq_str = "12345"
+    integer, parameter :: var_no_space=123
+    integer, parameter :: var_more_space  =   123
+    integer, parameter :: var_sum1  = 1 + 23
+    integer, parameter :: var_ex1  = 1 - 23
+    integer, parameter :: var_mul1  = 1  *   23
+    integer, parameter :: var_div1  = 1/1
 end program params


### PR DESCRIPTION
Trim trailing whitespaces. Modify one test and add one more `parameter_val` test with multiline definition.