### PR TITLE
Fix passing `incl_suffixes` as command line arguments to fortls

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -89,7 +89,7 @@ class LangServer:
 
         self.sync_type: int = 2 if self.incremental_sync else 1
         self.post_messages = []
-        self.FORTRAN_SRC_EXT_REGEX: Pattern[str] = src_file_exts()
+        self.FORTRAN_SRC_EXT_REGEX: Pattern[str] = src_file_exts(self.incl_suffixes)
         # Intrinsic (re-loaded during initialize)
         (
             self.statements,


### PR DESCRIPTION
Passing `--incl_suffix` to fortls as command line arguments did not take any effect. Although the arguments were parsed correctly and set as attributes to the `LangServer` instance, they where never passed to `src_file_exts` and hence got ignored later when iterating the root directory.

This is especially problematic when fortls is used via the Modern Fortran VS code extension when it tries to pass along settings from the `settings.json` file.