### PR TITLE
fix: rewrote the source file extension REGEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 ### Changed
 
+- Changed `--incl_suffixes` option to faithfully match the suffixes that are
+  provided in the option, without performing any type of modification.
+  ([#300](https://github.com/fortran-lang/fortls/issues/300))
 - Changed the completion signature to include the full Markdown documentation
   for the completion item.
   ([#219](https://github.com/fortran-lang/fortls/issues/219))

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -102,11 +102,15 @@ incl_suffixes
 .. code-block:: json
 
    {
-      "incl_suffixes": [".h", ".FYP"]
+      "incl_suffixes": [".h", ".FYP", "inc"]
    }
 
 ``fortls`` will parse only files with ``incl_suffixes`` extensions found in
-``source_dirs``. By default ``incl_suffixes`` are defined as
+``source_dirs``. Using the above example, ``fortls`` will match files by the
+``file.h`` and ``file.FYP``, but not ``file.fyp`` or ``filefyp``.
+It will also match ``file.inc`` and ``fileinc`` but not ``file.inc2``.
+
+By default, ``incl_suffixes`` are defined as
 .F .f .F03 .f03 .F05 .f05 .F08 .f08 .F18 .f18 .F77 .f77 .F90 .f90 .F95 .f95 .FOR .for .FPP .fpp.
 Additional source file extensions can be defined in ``incl_suffixes``.
 

--- a/fortls/fortls.schema.json
+++ b/fortls/fortls.schema.json
@@ -61,7 +61,7 @@
     },
     "incl_suffixes": {
       "title": "Incl Suffixes",
-      "description": "Consider additional file extensions to the default (default: F,F77,F90,F95,F03,F08,FOR,FPP (lower & upper casing))",
+      "description": "Consider additional file extensions to the default (default: .F, .F77, .F90, .F95, .F03, .F08, .FOR, .FPP (lower & upper casing))",
       "default": [],
       "type": "array",
       "items": {},

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -126,7 +126,7 @@ def cli(name: str = "fortls") -> argparse.ArgumentParser:
         metavar="SUFFIXES",
         help=(
             "Consider additional file extensions to the default (default: "
-            "F,F77,F90,F95,F03,F08,FOR,FPP (lower & upper casing))"
+            ".F, .F77, .F90, .F95, .F03, .F08, .FOR, .FPP (lower & upper casing))"
         ),
     )
     group.add_argument(

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -61,7 +61,7 @@ from fortls.objects import (
     get_use_tree,
 )
 from fortls.parse_fortran import FortranFile, get_line_context
-from fortls.regex_patterns import src_file_exts
+from fortls.regex_patterns import create_src_file_exts_str
 from fortls.version import __version__
 
 # Global regexes
@@ -89,7 +89,9 @@ class LangServer:
 
         self.sync_type: int = 2 if self.incremental_sync else 1
         self.post_messages = []
-        self.FORTRAN_SRC_EXT_REGEX: Pattern[str] = src_file_exts(self.incl_suffixes)
+        self.FORTRAN_SRC_EXT_REGEX: Pattern[str] = create_src_file_exts_str(
+            self.incl_suffixes
+        )
         # Intrinsic (re-loaded during initialize)
         (
             self.statements,
@@ -1569,7 +1571,7 @@ class LangServer:
         self.source_dirs = set(config_dict.get("source_dirs", self.source_dirs))
         self.incl_suffixes = set(config_dict.get("incl_suffixes", self.incl_suffixes))
         # Update the source file REGEX
-        self.FORTRAN_SRC_EXT_REGEX = src_file_exts(self.incl_suffixes)
+        self.FORTRAN_SRC_EXT_REGEX = create_src_file_exts_str(self.incl_suffixes)
         self.excl_suffixes = set(config_dict.get("excl_suffixes", self.excl_suffixes))
 
     def _load_config_file_general(self, config_dict: dict) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     black
     isort
     pre-commit
-    pydantic
+    pydantic==1.9.1
 docs =
     sphinx >= 4.0.0
     sphinx-argparse

--- a/test/test_regex_patterns.py
+++ b/test/test_regex_patterns.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from fortls.regex_patterns import create_src_file_exts_regex
+
+
+@pytest.mark.parametrize(
+    "input_exts, input_files, matches",
+    [
+        (
+            [],
+            [
+                "test.f",
+                "test.F",
+                "test.f90",
+                "test.F90",
+                "test.f03",
+                "test.F03",
+                "test.f18",
+                "test.F18",
+                "test.f77",
+                "test.F77",
+                "test.f95",
+                "test.F95",
+                "test.for",
+                "test.FOR",
+                "test.fpp",
+                "test.FPP",
+            ],
+            [True] * 16,
+        ),
+        ([], ["test.ff", "test.f901", "test.f90.ff"], [False, False, False]),
+        ([r"\.inc"], ["test.inc", "testinc", "test.inc2"], [True, False, False]),
+        (["inc.*"], ["test.inc", "testinc", "test.inc2"], [True, True, True]),
+    ],
+)
+def test_src_file_exts(
+    input_exts: list[str],
+    input_files: list[str],
+    matches: list[bool],
+):
+    regex = create_src_file_exts_regex(input_exts)
+    results = [bool(regex.search(file)) for file in input_files]
+    assert results == matches


### PR DESCRIPTION
The regex now allows for more failthul patterns to the input strings
to be formed.
In the future we should probably allow full regex expressions as inputs,
as opposed to now, where we escape special characters.

Fixes #300