### PR TITLE
Allow conda autoupdate

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -49,6 +49,7 @@ All the ``fortls`` settings with their default arguments can be found below
       "incremental_sync": false,
       "sort_keywords": false,
       "disable_autoupdate": false,
+      "allow_conda_autoupdate": false,
       "debug_log": false,
 
       "source_dirs": ["./**"],

--- a/fortls/fortls.schema.json
+++ b/fortls/fortls.schema.json
@@ -41,7 +41,7 @@
     },
     "allow_conda_autoupdate": {
       "title": "Allow Conda Autoupdate",
-      "description": "By default, fortls does not permit autoupdating in conda environments.  Use this option to enable fortls to automatically check conda-forge for newer version and install them.",
+      "description": "By default, fortls does not permit autoupdating in conda environments. Use this option to enable fortls to automatically check conda-forge for newer version and install them.",
       "default": false,
       "type": "boolean"
     },

--- a/fortls/fortls.schema.json
+++ b/fortls/fortls.schema.json
@@ -35,7 +35,13 @@
     },
     "disable_autoupdate": {
       "title": "Disable Autoupdate",
-      "description": "fortls automatically checks PyPi for newer version and installs them.Use this option to disable the autoupdate feature.",
+      "description": "fortls automatically checks PyPi for newer version and installs them. Use this option to disable the autoupdate feature.",
+      "default": false,
+      "type": "boolean"
+    },
+    "allow_conda_autoupdate": {
+      "title": "Allow Conda Autoupdate",
+      "description": "By default, fortls does not permit autoupdating in conda environments.  Use this option to enable fortls to automatically check conda-forge for newer version and install them.",
       "default": false,
       "type": "boolean"
     },

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -88,7 +88,16 @@ def cli(name: str = "fortls") -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "fortls automatically checks PyPi for newer version and installs them."
-            "Use this option to disable the autoupdate feature."
+            " Use this option to disable the autoupdate feature."
+        ),
+    )
+    parser.add_argument(
+        "--allow_conda_autoupdate",
+        action="store_true",
+        help=(
+            "By default, fortls does not permit autoupdating in conda environments."
+            " Use this option to enable fortls to automatically check conda-forge"
+            " for newer version and install them."
         ),
     )
     # XXX: Deprecated, argument not attached to anything. Remove

--- a/test/test_source/f90_config.json
+++ b/test/test_source/f90_config.json
@@ -4,6 +4,7 @@
   "incremental_sync": true,
   "sort_keywords": true,
   "disable_autoupdate": true,
+  "allow_conda_autoupdate": true,
 
   "source_dirs": ["subdir", "pp/**"],
   "incl_suffixes": [".FF", ".fpc", ".h", "f20"],


### PR DESCRIPTION
Disabled by default, but provides the option to allow autoupdating fortls when installed in a conda environment for those of us who do desire that functionality and don't mind it changing the environment.

Additionally fixes bug in unit test for updater where config file was not being properly loaded by the LangServer instance.