### PR TITLE
Allow dollar in symbol names

### DIFF
--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -2045,9 +2045,9 @@ def preprocess_file(
             out_line = ""
             for match in FRegex.DEFINED.finditer(line):
                 if match.group(1) in defs:
-                    out_line += line[i0 : match.start(0)] + "($@)"
+                    out_line += line[i0 : match.start(0)] + "(@$@)"
                 else:
-                    out_line += line[i0 : match.start(0)] + "($%)"
+                    out_line += line[i0 : match.start(0)] + "(%$%)"
                 i0 = match.end(0)
             if i0 < len(line):
                 out_line += line[i0:]
@@ -2064,8 +2064,8 @@ def preprocess_file(
                 i0 = match.end(0)
             if i0 < len(line):
                 out_line += line[i0:]
-            out_line = out_line.replace("$@", "True")
-            out_line = out_line.replace("$%", "False")
+            out_line = out_line.replace("@$@", "True")
+            out_line = out_line.replace("%$%", "False")
             return out_line
 
         if defs is None:

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -98,7 +98,7 @@ class FortranRegularExpressions:
         r"[ ]*,[ ]*(PUBLIC|PRIVATE|ABSTRACT|EXTENDS\(\w*\))", I
     )
     VIS: Pattern = compile(r"[ ]*\b(PUBLIC|PRIVATE)\b", I)
-    WORD: Pattern = compile(r"[a-z_]\w*", I)
+    WORD: Pattern = compile(r"[a-z_][\w\$]*", I)
     NUMBER: Pattern = compile(
         r"[\+\-]?(\b\d+\.?\d*|\.\d+)(_\w+|d[\+\-]?\d+|e[\+\-]?\d+(_\w+)?)?(?!\w)",
         I,
@@ -146,7 +146,7 @@ class FortranRegularExpressions:
     # Object regex patterns
     CLASS_VAR: Pattern = compile(r"(TYPE|CLASS)[ ]*\(", I)
     DEF_KIND: Pattern = compile(r"(\w*)[ ]*\((?:KIND|LEN)?[ =]*(\w*)", I)
-    OBJBREAK: Pattern = compile(r"[\/\-(.,+*<>=$: ]", I)
+    OBJBREAK: Pattern = compile(r"[\/\-(.,+*<>=: ]", I)
 
 
 # TODO: use this in the main code

--- a/test/test_server_hover.py
+++ b/test/test_server_hover.py
@@ -70,6 +70,17 @@ def test_hover_parameter():
     validate_hover(results, ref_results)
 
 
+def test_hover_parameter_dollar():
+    """Test that hover parameters with dollar in name are recognized correctly"""
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "hover" / "parameters.f90"
+    string += hover_req(file_path, 20, 31)
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
+    assert errcode == 0
+    ref_results = ["```fortran90\nINTEGER(4), PARAMETER :: SIG$ERR = -1\n```"]
+    validate_hover(results, ref_results)
+
+
 def test_hover_parameter_eqnospace():
     """Test that hover parameters display value correctly"""
     string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})

--- a/test/test_source/hover/parameters.f90
+++ b/test/test_source/hover/parameters.f90
@@ -18,4 +18,5 @@ program params
     INTEGER, PARAMETER :: var_multi2 = 1 *   &
                                         23 + &
                                         2 /1        ! comment
+    INTEGER(4), PARAMETER :: SIG$ERR   = -1
 end program params


### PR DESCRIPTION
Some language dialects allow dollar signs in symbol names.  In Intel, this is always allowed.  In g77, it can be enabled via [command line flag](https://gcc.gnu.org/onlinedocs/gcc-2.95.3/g77_13.html#SEC380).  This seems to be an older practice that has fallen out of favor and was always a language extension, but is needed to support backward compatibility with older codes.

I've opted to implement this as always allowed like the Intel implementation, but I can change this to be an opt-in feature if we'd rather.  I don't suspect it will hurt anyone to allow it.  

There are other noted historical uses of `$` in Fortran that are more rare, particularly with different variations of write statements, but it is unclear if any of these are still supported today by any compilers. (Even if they are, the current proposed regex is unlikely to erroneously match to them.)
