### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/workflows/update-intrinsics.yml
+++ b/.github/workflows/update-intrinsics.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Update Markdown intrinsics
         run: |
-          python3 -m fortls.intrinsics
+          python3 -m fortls.parsers.internal.intrinsics
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To build this project you will need [Python](https://www.python.org/) `>= 3.7` a
 To install all Python dependencies open a terminal go into the `fortls` cloned folder and run:
 
 ```sh
-pip install -e .\[dev,docs\]
+pip install -e ."[dev,docs]"
 ```
 
 ### Testing 🧪

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To build this project you will need [Python](https://www.python.org/) `>= 3.7` a
 To install all Python dependencies open a terminal go into the `fortls` cloned folder and run:
 
 ```sh
-pip install -e .[dev,docs]
+pip install -e .\[dev,docs\]
 ```
 
 ### Testing 🧪

--- a/fortls/parsers/internal/intrinsics.py
+++ b/fortls/parsers/internal/intrinsics.py
@@ -277,7 +277,9 @@ def update_m_intrinsics():
             val = val.replace(f"**{key.upper()}**(3)", f"**{key.upper()}**")
             markdown_intrinsics[key] = val
 
-        with open("fortls/parsers/internal/intrinsic.procedures.markdown.json", "w") as f:
+        with open(
+            "fortls/parsers/internal/intrinsic.procedures.markdown.json", "w"
+        ) as f:
             json.dump(markdown_intrinsics, f, indent=2)
             f.write("\n")  # add newline at end of file
     except Exception as e:

--- a/fortls/parsers/internal/intrinsics.py
+++ b/fortls/parsers/internal/intrinsics.py
@@ -277,7 +277,7 @@ def update_m_intrinsics():
             val = val.replace(f"**{key.upper()}**(3)", f"**{key.upper()}**")
             markdown_intrinsics[key] = val
 
-        with open("fortls/intrinsic.procedures.markdown.json", "w") as f:
+        with open("fortls/parsers/internal/intrinsic.procedures.markdown.json", "w") as f:
             json.dump(markdown_intrinsics, f, indent=2)
             f.write("\n")  # add newline at end of file
     except Exception as e:


### PR DESCRIPTION
The command wasn't working on zsh (which is default shell on macOS) as square brackets are used for pattern matching on zsh , using ' \ ' before square brackets works on both zsh and bash.