### PR TITLE
Addressing compatibility issue for shell script in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To build this project you will need [Python](https://www.python.org/) `>= 3.7` a
 To install all Python dependencies open a terminal go into the `fortls` cloned folder and run:
 
 ```sh
-pip install -e .[dev,docs]
+pip install -e ."[dev,docs]"
 ```
 
 ### Testing 🧪

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To build this project you will need [Python](https://www.python.org/) `>= 3.7` a
 To install all Python dependencies open a terminal go into the `fortls` cloned folder and run:
 
 ```sh
-pip install -e ."[dev,docs]"
+pip install -e ".[dev,docs]"
 ```
 
 ### Testing 🧪


### PR DESCRIPTION
Addresses compatibility issues with the shell script, making it work on zsh as well. Previously, the script was failing on zsh as square brackets are used for pattern matching in zsh. By adding double quotes, the script now functions correctly across different shell environments.

> pip install -e ".[dev,docs]"