### PR TITLE
fix/issue 265

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Fixed
 
+- Fixed end of scope errors raised by trailing semicolon in native parser
+  ([#265](https://github.com/fortran-lang/fortls/issues/265))
 - Fixed bug where parent scope for includes in AST could be `None`
   ([#329](https://github.com/fortran-lang/fortls/issues/329))
 - Fixed preprocessor bug with `if` and `elif` conditionals

--- a/fortls/debug.py
+++ b/fortls/debug.py
@@ -439,7 +439,8 @@ def debug_parser(args):
 
         # Check for config files
         config_path = locate_config(root)
-        if not os.path.isfile(config_path):
+        print(f"  Config file = {config_path}")
+        if config_path is None or not os.path.isfile(config_path):
             return pp_suffixes, pp_defs, include_dirs
 
         try:

--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -1350,6 +1350,7 @@ class FortranFile:
                 multi_lines.extendleft(line_stripped.split(";"))
                 line = multi_lines.pop()
                 line_stripped = line
+                line_no_comment = line
             # Test for scope end
             if file_ast.end_scope_regex is not None:
                 match = FRegex.END_WORD.match(line_no_comment)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -39,3 +39,12 @@ def test_private_visibility_interfaces():
     err_str, _ = file.load_from_disk()
     file.parse()
     assert err_str is None
+
+
+def test_end_scopes_semicolon():
+    file_path = test_dir / "parse" / "trailing_semicolon.f90"
+    file = FortranFile(str(file_path))
+    err_str, _ = file.load_from_disk()
+    ast = file.parse()
+    assert err_str is None
+    assert not ast.end_errors

--- a/test/test_source/parse/trailing_semicolon.f90
+++ b/test/test_source/parse/trailing_semicolon.f90
@@ -1,0 +1,6 @@
+program trailing_semicolon_in_end_scope
+  integer :: i
+  do i=1, 3
+      print *, "Hello World!"
+  end do;
+end program trailing_semicolon_in_end_scope


### PR DESCRIPTION
- **fix(debug): config file handling**
- **fix(parser): trailing semicolons triggering end of scope diagnostics**
