### PR TITLE
fix(parser): preproc operator mixed with line cont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug where parser would crash when trying to retrieve an invalid line no.
+  ([#398](https://github.com/fortran-lang/fortls/issues/398))
+
 ## 3.0.0
 
 ### Added

--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -1104,6 +1104,9 @@ class FortranFile:
                     elif next_line != "":
                         post_lines[-1] = next_line[:iAmper]
                     next_line = self.get_line(line_ind, pp_content)
+                    if next_line is None:
+                        break
+
                     line_ind += 1
                     # Skip any preprocessor statements when seeking the next line
                     if FRegex.PP_ANY.match(next_line):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,3 +1,4 @@
+import pytest
 from setup_tests import test_dir
 
 from fortls.parsers.internal.parser import FortranFile
@@ -57,3 +58,41 @@ def test_weird_parser_bug():
     ast = file.parse()
     assert err_str is None
     assert not ast.end_errors
+
+
+@pytest.mark.parametrize(
+    "ln_no, pp_defs, reference",
+    [
+        (6, {}, 6),
+        (7, {}, 6),
+        (8, {}, 6),
+        (11, {"TEST": True}, 60),  # not entirely correct ref vals
+        (23, {"MULT": True}, 90),  # not entirely correct ref vals
+        (32, {"TEST": True, "MULT": True}, 130),  # not entirely correct ref vals
+        (39, {"TEST": True, "MULT": True}, 2400),  # not entirely correct ref vals
+    ],
+)
+def test_get_code_line_multilines(ln_no: int, pp_defs: dict, reference: int):
+    """Tests how the get_code_line performs with multi-line and preprocessor
+
+    Not all the results are correct, since get_code_line is not aware of the
+    preprocessor skips. Instead what it does is it evaluates all the line
+    continuations and appends them in post.
+    """
+
+    def calc_result(res: tuple):
+        pre, cur, post = res
+        res = "".join(pre + [cur] + post).replace(" ", "")
+        assert "result" in res, "Fortran variable `result` not found in results"
+        loc = {}
+        exec(res, None, loc)
+        return loc["result"]
+
+    file_path = test_dir / "parse" / "mixed" / "multilines.F90"
+    file = FortranFile(str(file_path))
+    file.load_from_disk()
+    file.preprocess(pp_defs=pp_defs)
+    pp = bool(pp_defs)
+    res = file.get_code_line(line_no=ln_no, pp_content=pp)
+    result = calc_result(res)
+    assert result == reference

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -48,3 +48,12 @@ def test_end_scopes_semicolon():
     ast = file.parse()
     assert err_str is None
     assert not ast.end_errors
+
+
+def test_weird_parser_bug():
+    file_path = test_dir / "parse" / "mixed" / "preproc_and_normal_syntax.F90"
+    file = FortranFile(str(file_path))
+    err_str, _ = file.load_from_disk()
+    ast = file.parse()
+    assert err_str is None
+    assert not ast.end_errors

--- a/test/test_source/.fortls
+++ b/test/test_source/.fortls
@@ -10,6 +10,7 @@
     "docs",
     "rename",
     "parse",
+    "parse/mixed/**",
     "vis"
   ]
 

--- a/test/test_source/parse/.fortls
+++ b/test/test_source/parse/.fortls
@@ -1,0 +1,5 @@
+{
+  "excl_paths": [
+    "mixed"
+  ]
+}

--- a/test/test_source/parse/mixed/multilines.F90
+++ b/test/test_source/parse/mixed/multilines.F90
@@ -1,0 +1,49 @@
+program multiline_tests
+  implicit none
+  integer :: result
+  character(len=100) :: str
+
+  ! Test: Simple multi-line continuation
+  result = 1 + &
+    2 + &
+    3
+
+  ! Test: Multi-line continuation with a preprocessor directive
+  result = 10 + &
+#ifdef TEST
+    20 + &
+#endif
+    30
+
+  ! Test: Multi-line continuation with string concatenation
+  str = 'Hello' // &
+  & ' ' // &
+  &  'World'
+
+  ! Test: Multi-line continuation with mixed preprocessor and arithmetic operations
+  result = &
+#ifdef MULT
+    (10*2) + &
+#else
+    (10 * 3) + &
+#endif
+  & 10 * 4
+
+  ! Test: Multi-line continuation with C preprocessor && sequence
+  result = 100 + &
+#if defined(TEST) && defined(MULT)
+  &(20) + &
+#endif
+  &10
+
+  ! Test: multiplee Multi-line continuation with C preprocessor and comments
+  result = 1000 + & ! Comment 0
+#if defined( TEST ) && defined( MULT )
+  &100 + &  ! Comment 1
+  &200+&    !! Comment 2
+#else
+    500 + & !!! Comment 3
+#endif
+  &600
+
+end program multiline_tests

--- a/test/test_source/parse/mixed/preproc_and_normal_syntax.F90
+++ b/test/test_source/parse/mixed/preproc_and_normal_syntax.F90
@@ -1,0 +1,5 @@
+
+  USE base_hooks
+#if VAR < 8 || VAR == 8 && VAR2 < 3
+#define OMP_DEFAULT_NONE_WITH_OOP NONE
+#endif


### PR DESCRIPTION
The logical operator `&&` present in the preprocessor
expressions interfered with the line continuation operator
`&` thus resulting into invalid syntax

Fixed #398
