### PR TITLE
fix(lsp): use correct symbol for submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed incorrect document symbol for `SUBMODULE` statements
+  ([#413](https://github.com/fortran-lang/fortls/issues/413))
+
 ## 3.1.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.1.2
+
 ### Fixed
 
 - Fixed incorrect document symbol for `SUBMODULE` statements

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -279,7 +279,7 @@ class LangServer:
 
     def serve_document_symbols(self, request: dict):
         def map_types(type, in_class: bool = False):
-            if type == 1:
+            if type in (1, 8):
                 return 2
             elif type in (2, 3):
                 if in_class:


### PR DESCRIPTION
Fixes #413
