### PR TITLE
fix: not treat form feed as line break (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed bug with Fixed Format references being incorrectly detected in comments
   ([#447](https://github.com/fortran-lang/fortls/issues/447))
+- Fixed bug with where form feed characters broke LSP features
+  ([#443](https://github.com/fortran-lang/fortls/issues/443))
 
 ## 3.1.2
 

--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -840,6 +840,11 @@ def find_external(
     return False
 
 
+def splitlines(text: str) -> list[str]:
+    """Split text into lines by \r\n, \n, or \r"""
+    return re.split(r"\n|\r\n?", text)
+
+
 class FortranFile:
     def __init__(self, path: str = None, pp_suffixes: list = None):
         self.path: str = path
@@ -900,7 +905,7 @@ class FortranFile:
                 return None, False
 
             self.hash = hash
-            self.contents_split = contents.splitlines()
+            self.contents_split = splitlines(contents)
             self.fixed = detect_fixed_format(self.contents_split)
             self.contents_pp = self.contents_split
             self.nLines = len(self.contents_split)
@@ -956,7 +961,7 @@ class FortranFile:
         if len(text) == 0:
             text_split = [""]
         else:
-            text_split = text.splitlines()
+            text_split = splitlines(text)
             # Check for ending newline
             if (text[-1] == "\n") or (text[-1] == "\r"):
                 text_split.append("")


### PR DESCRIPTION
This is the suggested fix for issue #443. Please see it for the exact description about what this fix is trying to address.

The issue is caused by splitting the code into lines using `str.splitlines` built-in function, which has a different set of line separators than the editors. (See https://docs.python.org/3/library/stdtypes.html#str.splitlines ) This fix is using our own `splitlines` function instead to make the line separation rule more consistent with the editors.

Now fortls can return the correct information regardless of the form feed characters in the code.
<img width="320" alt="image" src="https://github.com/user-attachments/assets/865629ad-7ebb-465a-b850-d6b8d55846d5">
