### PR TITLE
fix: catch RecursionError in initialization

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1491,8 +1491,12 @@ class LangServer:
         for path, result in results.items():
             try:
                 result_obj = result.get()
-            except:
-                result_obj = traceback.format_exc()
+            except Exception as e:
+                result_obj = (
+                    "An exception has occured while initialising the workspace.\n"
+                    f"Exception({(type(e))}): {e}\n"
+                    + f"Traceback: {traceback.format_exc()}"
+                )
             if isinstance(result_obj, str):
                 self.post_message(
                     f"Initialization failed for file {path}: {result_obj}"

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1489,7 +1489,10 @@ class LangServer:
         pool.close()
         pool.join()
         for path, result in results.items():
-            result_obj = result.get()
+            try:
+                result_obj = result.get()
+            except:
+                result_obj = traceback.format_exc()
             if isinstance(result_obj, str):
                 self.post_message(
                     f"Initialization failed for file {path}: {result_obj}"

--- a/test/test_server_init.py
+++ b/test/test_server_init.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+
+import pytest
+from setup_tests import Path, run_request, write_rpc_request
+
+from fortls.constants import Severity
+
+
+@pytest.fixture()
+def setup_tmp_file():
+    levels = 2000
+    fd, filename = tempfile.mkstemp(suffix=".f90")
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            tmp.write(
+                "program nested_if\n"
+                + str("if (.true.) then\n" * levels)
+                + str("end if\n" * levels)
+                + "end program nested_if"
+            )
+        yield filename
+    finally:
+        os.remove(filename)
+
+
+def test_recursion_error_handling(setup_tmp_file):
+    root = Path(setup_tmp_file).parent
+    request_string = write_rpc_request(1, "initialize", {"rootPath": str(root)})
+    errcode, results = run_request(request_string)
+    assert errcode == 0
+    assert results[0]["type"] == Severity.error


### PR DESCRIPTION
This is the suggested fix for #445. Please see #445 for the exact description about what this fix is trying to address.

The issue can be addressed by catching the errors raised from `result.get()` (receivning the result from the child process) in `LangServer.workspace_init`. The caught error can be convereted to string so that it will be posted as an error message.

With this fix, the fortls reports an "Initialization failed" message for the file that caused the RecusrionError, and successfully completes the initialization instead of crashing itself. It looks like below in VSCode (The red underline indicates the file that caused the issue).

<img width="926" alt="image" src="https://github.com/user-attachments/assets/6fbfb510-c86e-46f4-882e-7f3073783701">