### PR TITLE
fix: flip the condition in strip_comment for fixed format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug with Fixed Format references being incorrectly detected in comments
+  ([#447](https://github.com/fortran-lang/fortls/issues/447))
+
 ## 3.1.2
 
 ### Fixed

--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -1137,7 +1137,7 @@ class FortranFile:
     def strip_comment(self, line: str) -> str:
         """Strip comment from line"""
         if self.fixed:
-            if FRegex.FIXED_COMMENT.match(line) and FRegex.FIXED_OPENMP.match(line):
+            if FRegex.FIXED_COMMENT.match(line) and not FRegex.FIXED_OPENMP.match(line):
                 return ""
         else:
             if FRegex.FREE_OPENMP.match(line) is None:

--- a/test/test_server_references.py
+++ b/test/test_server_references.py
@@ -51,3 +51,12 @@ def test_references():
             [free_path, 78, 6, 12],
         ),
     )
+
+
+def test_references_ignore_comments_fixed():
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir / "fixed")})
+    file_path = test_dir / "fixed" / "comment_as_reference.f"
+    string += ref_req(file_path, 3, 22)
+    errcode, results = run_request(string)
+    assert errcode == 0
+    assert len(results[1]) == 2

--- a/test/test_source/fixed/comment_as_reference.f
+++ b/test/test_source/fixed/comment_as_reference.f
@@ -1,0 +1,5 @@
+      program comment_as_reference
+C     Comment with variable name gets picked as a ref: variable_to_reference
+      real variable_to_reference
+      variable_to_reference = 1
+      end program comment_as_reference


### PR DESCRIPTION
This is the suggested fix for https://github.com/fortran-lang/fortls/issues/447. Please see https://github.com/fortran-lang/fortls/issues/447 for the exact description about what this fix is trying to address.

As pointed out in the issue above, it looks like a simple mistake in the condition for stripping comments. It works fine as below just by flipping the condition about the OpenMP instruction.

<img src="https://github.com/user-attachments/assets/4cd59bd4-22f2-4e35-919a-703dc8767126" width="480">
