### PR TITLE
Fix: Return None in find_word_in_line when word is not found

### DIFF
--- a/fortls/helper_functions.py
+++ b/fortls/helper_functions.py
@@ -204,7 +204,7 @@ def separate_def_list(test_str: str) -> list[str] | None:
     return def_list
 
 
-def find_word_in_line(line: str, word: str) -> Range:
+def find_word_in_line(line: str, word: str) -> Range | None:
     """Find Fortran word in line
 
     Parameters
@@ -228,7 +228,8 @@ def find_word_in_line(line: str, word: str) -> Range:
         ),
         -1,
     )
-    # TODO: if i == -1: return None makes more sense
+    if i == -1:
+        return None
     return Range(i, i + len(word))
 
 

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1771,7 +1771,17 @@ class LangServer:
     def _create_ref_link(self, obj) -> dict:
         """Create a link reference to an object"""
         obj_file: FortranFile = obj.file_ast.file
-        sline, (schar, echar) = obj_file.find_word_in_code_line(obj.sline - 1, obj.name)
+        result = obj_file.find_word_in_code_line(obj.sline - 1, obj.name)
+        if result is None:
+            return uri_json(
+                path_to_uri(obj_file.path), obj.sline - 1, 0, obj.sline - 1, 0
+            )
+        sline, word_range = result
+        if word_range is None:
+            return uri_json(
+                path_to_uri(obj_file.path), obj.sline - 1, 0, obj.sline - 1, 0
+            )
+        schar, echar = word_range.start, word_range.end
         if schar < 0:
             schar = echar = 0
         return uri_json(path_to_uri(obj_file.path), sline, schar, sline, echar)

--- a/fortls/parsers/internal/diagnostics.py
+++ b/fortls/parsers/internal/diagnostics.py
@@ -29,7 +29,7 @@ class Diagnostic:
             self.sline, obj_range = file_obj.find_word_in_code_line(
                 self.sline, self.find_word
             )
-            if obj_range.start >= 0:
+            if obj_range is not None:
                 schar = obj_range.start
                 echar = obj_range.end
         diag = diagnostic_json(

--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -1156,25 +1156,25 @@ class FortranFile:
         forward: bool = True,
         backward: bool = False,
         pp_content: bool = False,
-    ) -> tuple[int, Range]:
+    ) -> tuple[int, Range | None]:
         back_lines, curr_line, forward_lines = self.get_code_line(
             line_no, forward=forward, backward=backward, pp_content=pp_content
         )
-        word_range = Range(-1, -1)
+        word_range = None
         if curr_line is not None:
             find_word_lower = word.lower()
             word_range = find_word_in_line(curr_line.lower(), find_word_lower)
-        if backward and (word_range.start < 0):
+        if backward and (word_range is None):
             back_lines.reverse()
             for i, line in enumerate(back_lines):
                 word_range = find_word_in_line(line.lower(), find_word_lower)
-                if word_range.start >= 0:
+                if word_range is not None:
                     line_no -= i + 1
                     return line_no, word_range
-        if forward and (word_range.start < 0):
+        if forward and (word_range is None):
             for i, line in enumerate(forward_lines):
                 word_range = find_word_in_line(line.lower(), find_word_lower)
-                if word_range.start >= 0:
+                if word_range is not None:
                     line_no += i + 1
                     return line_no, word_range
         return line_no, word_range

--- a/test/test_server_definitions.py
+++ b/test/test_server_definitions.py
@@ -9,8 +9,11 @@ def validate_def(result_array, checks):
         assert not checks[0]
         return None
     assert result_array["uri"] == path_to_uri(checks[2])
-    assert result_array["range"]["start"]["line"] == checks[0]
-    assert result_array["range"]["start"]["line"] == checks[1]
+    if result_array["range"] is not None:
+        assert result_array["range"]["start"]["line"] == checks[0]
+        assert result_array["range"]["start"]["line"] == checks[1]
+    else:
+        assert checks[0] is None
 
 
 def def_request(uri: Path, line, char):


### PR DESCRIPTION
This PR addresses a TODO in the `find_word_in_line` function, which suggested that returning `None` when the word is not found would make more sense than returning a `Range(-1, -1)`. 

I modified `find_word_in_line` to return `None` when the word is not found as suggested, and updated `find_word_in_code_line` to handle the `None` return value