### PR TITLE
fix: diagnostic error for interface arguments

### DIFF
--- a/fortls/parsers/internal/subroutine.py
+++ b/fortls/parsers/internal/subroutine.py
@@ -86,7 +86,7 @@ class Subroutine(Scope):
                 # block's children i.e. functions and subroutines to see if one matches
                 elif child.name.lower().startswith("#gen_int"):
                     for sub_child in child.children:
-                        if arg == sub_child.name:
+                        if arg == sub_child.name.lower():
                             self.arg_objs[i] = sub_child
                             break
 

--- a/test/test_server_diagnostics.py
+++ b/test/test_server_diagnostics.py
@@ -440,3 +440,18 @@ def test_critical_scope():
     errcode, results = run_request(string, ["-n", "1"])
     assert errcode == 0
     assert results[1]["diagnostics"] == []
+
+
+def test_mixed_case_interface_sub_child():
+    """
+    Test that interface sub_child arguments are correctly resolved
+    regardless of their case.
+    """
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir / "diag")})
+    file_path = str(test_dir / "diag" / "mixed_case_interface_sub_child.f90")
+    string += write_rpc_notification(
+        "textDocument/didOpen", {"textDocument": {"uri": file_path}}
+    )
+    errcode, results = run_request(string, ["-n", "1"])
+    assert errcode == 0
+    assert results[1]["diagnostics"] == []

--- a/test/test_source/diag/test_mixed_case_interface_sub_child.f90
+++ b/test/test_source/diag/test_mixed_case_interface_sub_child.f90
@@ -1,0 +1,11 @@
+module mixed_case_interface_sub_child
+  implicit none
+
+contains
+  subroutine foo(Func)
+    interface
+      function Func()
+      end function Func
+    end interface
+  end subroutine foo
+end module mixed_case_interface_sub_child


### PR DESCRIPTION
This commit fixes a bug where the sub children of an
interface would not be properly checked for their letter case.

Fixes #471
