### PR TITLE
Fix missing write permission for pr-preview-action

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -1,6 +1,7 @@
 name: Docs Preview
 
 permissions:
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
The `contents: write` permission is required for the `rossjrw/pr-preview-action` to push the generated documentation to the `gh-pages` branch. Without this permission, the GitHub Actions bot cannot write to the repository, resulting in the 403 error.