### PR TITLE
Fix crash on function-like macros with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Fixed a crash (`re.error: invalid group reference`) when a source file defines
+  a function-like macro with no arguments, e.g. `#define ok() ...`
+  ([#486](https://github.com/fortran-lang/fortls/issues/486))
 - Fixed missing registered capability for `textDocument/documentHighlight`
   ([#421](https://github.com/fortran-lang/fortls/issues/421s))
 

--- a/fortls/parsers/internal/parser.py
+++ b/fortls/parsers/internal/parser.py
@@ -2086,11 +2086,17 @@ def preprocess_file(
 
     def expand_func_macro(def_name: str, def_value: tuple[str, str]):
         def_args, sub = def_value
-        def_args = def_args.split(",")
+        # "".split(",") is [""], not [], so a zero-argument macro such as
+        # `#define ok() ...` used to be treated as having one unnamed argument.
+        # The substitution below then ran `\b()\b`, which matches at every word
+        # boundary, and peppered the replacement text with group references --
+        # `ie/=0` became `...\10`, i.e. a reference to group 10, and re raised
+        # "invalid group reference". Drop empty names so the count is honest.
+        def_args = [arg for arg in (a.strip() for a in def_args.split(",")) if arg]
         regex = re.compile(rf"\b{def_name}\s*\({','.join(['(.*)']*len(def_args))}\)")
 
         for i, arg in enumerate(def_args, start=1):
-            sub = re.sub(rf"\b({arg.strip()})\b", rf"\\{i}", sub)
+            sub = re.sub(rf"\b({re.escape(arg)})\b", rf"\\{i}", sub)
 
         return regex, sub
 

--- a/test/test_preproc_parser.py
+++ b/test/test_preproc_parser.py
@@ -39,7 +39,7 @@ def test_pp_macro_expansion():
 
 
 def test_pp_zero_argument_function_macro():
-    """A function-like macro with no arguments expands without crashing.
+    r"""A function-like macro with no arguments expands without crashing.
 
     Regression test for #486. `"".split(",")` is `[""]`, not `[]`, so a macro
     such as `ok()` was treated as having one unnamed argument. The argument

--- a/test/test_preproc_parser.py
+++ b/test/test_preproc_parser.py
@@ -36,3 +36,48 @@ def test_pp_macro_expansion():
     ]
     output, _, _, _ = preprocess_file(lines)
     assert output == ref
+
+
+def test_pp_zero_argument_function_macro():
+    """A function-like macro with no arguments expands without crashing.
+
+    Regression test for #486. `"".split(",")` is `[""]`, not `[]`, so a macro
+    such as `ok()` was treated as having one unnamed argument. The argument
+    substitution then ran `\b()\b`, which matches at every word boundary, and
+    injected group references throughout the replacement text -- `ie/=0` became
+    `...\10`, and `re` raised "invalid group reference 10".
+    """
+    lines = [
+        "#define ok() if(ie/=0) then; return; end if;",
+        "subroutine b",
+        "integer :: ie",
+        "ie = 1",
+        "ok()",
+        "end subroutine",
+    ]
+    ref = [
+        "#define ok() if(ie/=0) then; return; end if;",
+        "subroutine b",
+        "integer :: ie",
+        "ie = 1",
+        "if(ie/=0) then; return; end if;",
+        "end subroutine",
+    ]
+    output, _, _, _ = preprocess_file(lines)
+    assert output == ref
+
+
+def test_pp_function_macro_arities():
+    """Zero, one and two argument macros all expand correctly."""
+    lines = [
+        "#define NOARG() 42",
+        "#define SQUARE(x) ((x)*(x))",
+        "#define ADD(a, b) ((a) + (b))",
+        "i = NOARG()",
+        "j = SQUARE(3)",
+        "k = ADD(1, 2)",
+    ]
+    output, _, _, _ = preprocess_file(lines)
+    # The leading space in "( 2)" is pre-existing behaviour: argument capture
+    # does not strip whitespace. Asserted as-is so this test stays about arity.
+    assert output[3:] == ["i = 42", "j = ((3)*(3))", "k = ((1) + ( 2))"]


### PR DESCRIPTION
## Problem

A file containing a function-like macro with no arguments makes fortls abort while preprocessing:

```
re.PatternError: invalid group reference 10
```

The file, and every module it defines, then silently fails to parse — which is why #486 reports that go-to-definition, hover and completion all stop working, including for code outside the module.

Minimal reproduction from the issue:

```fortran
#define ok() if(ie/=0) then; return; end if;

module A
    implicit none
contains
    subroutine B
    integer :: ie
    ie = 1
    ok()
    end subroutine
end module
```

The reporter noticed that `#define ok ...` works while `#define ok() ...` does not, which is the giveaway: the object-like and function-like paths differ.

## Cause

`expand_func_macro` splits the argument list with `def_args.split(",")`. For a zero-argument macro the argument list is the empty string, and `"".split(",")` returns `[""]`, not `[]` — so the macro is treated as having one unnamed argument.

The substitution loop then runs:

```python
re.sub(r"\b()\b", r"\1", sub)
```

That pattern matches the empty string at every word boundary, so group references get injected all through the replacement text. In the reported macro body one lands immediately before a digit in `ie/=0`, producing the literal `\10` — which `re` reads as a reference to group 10 when the text is later used as a substitution template. Hence the error, and hence why the value 10 looks arbitrary.

## Solution

Drop empty names before the argument count is taken. A zero-argument macro then compiles to `\bok\s*\(\)` and no argument substitution runs over its body.

Argument names are also passed through `re.escape`, which they were not before.

## Testing

Two tests added to `test/test_preproc_parser.py`:

- `test_pp_zero_argument_function_macro` — the issue's macro expands to its body instead of raising
- `test_pp_function_macro_arities` — zero, one and two argument macros all expand correctly, so the fix does not regress the argument path

Both fail without the change. Full suite: 183 passed. `pre-commit` (flake8, black, isort, pyupgrade) clean.

One note: the two-argument expectation asserts `((1) + ( 2))` with the leading space intact. Argument capture does not strip whitespace, which is pre-existing behaviour and left alone so this change stays about the crash.

Fixes #486