### PR TITLE
Rename the implicit result variable along with its function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fixed missing registered capability for `textDocument/documentHighlight`
   ([#421](https://github.com/fortran-lang/fortls/issues/421s))
 
+- Fixed `textDocument/rename` not renaming the implicit result variable of a
+  function declared without a `RESULT()` clause
+  ([#322](https://github.com/fortran-lang/fortls/issues/322))
+
 ## 3.2.2
 
 ### Fixed

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -969,6 +969,27 @@ class LangServer:
         # A container that includes all the FQSN signatures for objects that
         # are linked to the rename request and that should also be replaced
         override_cache: list[str] = []
+        # A function without an explicit RESULT() clause returns through an
+        # implicit result variable that shares the function's name but is a
+        # distinct object with its own FQSN, e.g. `mod::fun` vs
+        # `mod::fun::fun`. The two must always be renamed together or the code
+        # stops compiling, so link them in both directions.
+        result_obj = getattr(def_obj, "result_obj", None)
+        if (
+            def_obj.get_type() == FUNCTION_TYPE_ID
+            and result_obj is not None
+            and def_obj.result_name.lower() == def_name
+        ):
+            override_cache.append(result_obj.FQSN)
+        else:
+            parent = getattr(def_obj, "parent", None)
+            if (
+                parent is not None
+                and parent.get_type() == FUNCTION_TYPE_ID
+                and getattr(parent, "result_obj", None) is def_obj
+                and parent.result_name.lower() == parent.name.lower()
+            ):
+                override_cache.append(parent.FQSN)
         refs = {}
         ref_objs = []
         for filename, file_obj in file_set:

--- a/test/test_server_rename.py
+++ b/test/test_server_rename.py
@@ -199,3 +199,63 @@ def test_rename_skip_intrinsic():
     errcode, results = run_request(string, ["-n", "1"])
     # FIXME: to be implemented
     assert errcode == 0
+
+
+def test_rename_implicit_function_result():
+    """Test that renaming a function without a RESULT() clause also renames the
+    implicit result variable in the function body, see issue #322.
+    """
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir / "rename")})
+    file_path = test_dir / "rename" / "test_rename_implicit_result.f90"
+    string += rename_request("sin_deg", file_path, 7, 25)
+    errcode, results = run_request(string, ["-n", "1"])
+    assert errcode == 0
+    ref = {}
+    ref[path_to_uri(str(file_path))] = [
+        create("sin_deg", 7, 23, 7, 27),
+        create("sin_deg", 9, 8, 9, 12),
+    ]
+    # zip() in check_rename_response silently ignores missing changes,
+    # so assert the count explicitly
+    assert len(results[1]["changes"][path_to_uri(str(file_path))]) == 2
+    check_rename_response(results[1]["changes"], ref)
+
+
+def test_rename_implicit_function_result_from_body():
+    """Test that renaming from the implicit result variable in the body also
+    renames the function definition, see issue #322.
+    """
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir / "rename")})
+    file_path = test_dir / "rename" / "test_rename_implicit_result.f90"
+    string += rename_request("sin_deg", file_path, 9, 9)
+    errcode, results = run_request(string, ["-n", "1"])
+    assert errcode == 0
+    ref = {}
+    ref[path_to_uri(str(file_path))] = [
+        create("sin_deg", 7, 23, 7, 27),
+        create("sin_deg", 9, 8, 9, 12),
+    ]
+    # zip() in check_rename_response silently ignores missing changes,
+    # so assert the count explicitly
+    assert len(results[1]["changes"][path_to_uri(str(file_path))]) == 2
+    check_rename_response(results[1]["changes"], ref)
+
+
+def test_rename_explicit_function_result():
+    """Test that a function with an explicit RESULT() clause only renames the
+    result variable, not the function name, see issue #322.
+    """
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir / "rename")})
+    file_path = test_dir / "rename" / "test_rename_implicit_result.f90"
+    string += rename_request("res", file_path, 16, 9)
+    errcode, results = run_request(string, ["-n", "1"])
+    assert errcode == 0
+    ref = {}
+    ref[path_to_uri(str(file_path))] = [
+        create("res", 14, 39, 14, 40),
+        create("res", 16, 8, 16, 9),
+    ]
+    # zip() in check_rename_response silently ignores missing changes,
+    # so assert the count explicitly
+    assert len(results[1]["changes"][path_to_uri(str(file_path))]) == 2
+    check_rename_response(results[1]["changes"], ref)

--- a/test/test_source/rename/test_rename_implicit_result.f90
+++ b/test/test_source/rename/test_rename_implicit_result.f90
@@ -1,0 +1,20 @@
+module test_rename_implicit_result
+    implicit none
+contains
+
+    ! No RESULT() clause: the function returns through an implicit result
+    ! variable that shares the function's name. Renaming the function must
+    ! rename the assignment below too. See issue #322.
+    real pure function sind(x)
+        real, intent(in), value :: x
+        sind = sin(x*((4.0*atan(1.0))/180.0))
+    end function
+
+    ! Explicit RESULT() clause: the function name is not a variable in the
+    ! body, so renaming the function must NOT touch `r`.
+    real function withresult(x) result(r)
+        real, intent(in) :: x
+        r = x*3.0
+    end function
+
+end module test_rename_implicit_result


### PR DESCRIPTION
Fixes #322

## The bug

A Fortran function declared without a `RESULT()` clause returns through an
implicit result variable that shares the function's name:

```fortran
real pure function sind(x)
    real, intent(in), value :: x
    sind = sin(x*((4.0*atan(1.0))/180.0))   ! <- implicit result variable
end function
```

Renaming `sind` renamed only the declaration and left the assignment alone,
producing code that no longer compiles.

## Root cause

fortls models the implicit result variable as a distinct object with its own
FQSN. For the function above:

| site | resolves to | FQSN |
|---|---|---|
| `function sind(x)` | `Function` | `m::sind` |
| `sind = ...` | `Variable` | `m::sind::sind` |

`get_all_references` matches candidates with `def_fqsn == var_def.FQSN`
(`langserver.py:994`), so the body occurrence never matched and was dropped.

Two things worth noting, since the issue speculated about both:

- **This is not the intrinsic collision.** A plain user function named
  `myfunc` fails identically, so `sind` shadowing the intrinsic is not
  involved. After this change the original `sind` case renames correctly and
  the `sin`/`atan` calls on the same line are still left alone.
- **Functions with an explicit `RESULT()` clause were never affected** —
  there both sites resolve to the same `Variable`, so they already matched.

`textDocument/definition` already resolved the body occurrence to the
function, so rename and definition disagreed with each other.

## The fix

Link the function and its implicit result variable through the existing
`override_cache`, in both directions, so a rename started from the
declaration *or* from the body updates both sites. The link is only made when
`result_name == name`, i.e. when the result variable really is implicit;
explicit `RESULT()` clauses take the existing path untouched.

`textDocument/references` and `documentHighlight` share this code path and are
fixed by the same change:

```
before:  myfunc.f90 (3, 24)
after:   myfunc.f90 (3, 24)
         myfunc.f90 (5, 9)
```

## Tests

Three tests plus a new fixture, `test_rename_implicit_result.f90`:

- `test_rename_implicit_function_result` — rename from the declaration
- `test_rename_implicit_function_result_from_body` — rename from the body
- `test_rename_explicit_function_result` — explicit `RESULT()` unchanged

The first two fail on `master` and pass here; the third passes either way and
guards against a regression.

They assert the *number* of changes explicitly, because
`check_rename_response` zips changes against expectations and would otherwise
silently pass when a change is missing — which is exactly the failure mode
here.

Full suite: 184 passed. `pre-commit` clean.
